### PR TITLE
TypeError: RedisProtocol.delete received 'str'

### DIFF
--- a/sanic_session/redis_session_interface.py
+++ b/sanic_session/redis_session_interface.py
@@ -90,7 +90,7 @@ class RedisSessionInterface(BaseSessionInterface):
 
         if not request['session']:
             await redis_connection.delete(
-                self.prefix + request['session'].sid)
+                [self.prefix + request['session'].sid])
 
             if request['session'].modified:
                 self._delete_cookie(request, response)


### PR DESCRIPTION
I got below error when using `RedisSessionInterface`, this pr only fixes for `async_redis` library, not try for others, such as `hiredis`, etc., you can find a better way to fix this kind of error:
```
TypeError: RedisProtocol.delete received 'str', expected (<class 'list'>, <class 'generator'>)
```
And, `async_redis.delete` accepts a list as parameter.
[http://asyncio-redis.readthedocs.io/en/latest/pages/reference.html#asyncio_redis.RedisProtocol.delete](url)